### PR TITLE
Correct typo that fixes breaking change: "ReferenceError: contents is…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-gulp-asset-rev-hash
+gulp-asset-rev-hasher
 =============
 
 > Keeps a file's hash in file's links to your assets. For automatic cache updating purpose.
-> Fork from gulp-rev-hash
+> Forked from https://github.com/vladlavrik/gulp-asset-rev-hash
 
 ## Install
 

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ module.exports = function(options) {
       var ext = path.extname(file.path);
 
       if (options.usePale) {
-        content = contents.replace(paleReg, function (a, b) {
+        content = content.replace(paleReg, function (a, b) {
           var sections = options.removeTags ? b : a;
           return handle(sections, ext, dir);
         });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "gulp-asset-rev-hash",
-  "version": "0.0.12",
-  "description": "Appends a file's hash to a file URL to cache assets in any file (html, templates). Fork from gulp-rev-hash",
+  "name": "gulp-asset-rev-hasher",
+  "version": "0.0.13",
+  "description": "Appends a file's hash to a file URL to cache assets in any file (html, templates). Forked from gulp-asset-rev-hash",
   "main": "index.js",
   "dependencies": {
     "gulp-util": "~2.2.14",
@@ -24,7 +24,7 @@
     "md5",
     "hash"
   ],
-  "author": "VladLavrik <lavrik@ukr.net.com>",
+  "author": "Harry Lincoln <harrylincoln0612@gmail.com>",
   "license": "MIT",
   "engines": {
     "node": ">=0.8"


### PR DESCRIPTION
Correct typo to fix compilation error:
```
        content = contents.replace(paleReg, function (a, b) {
                  ^
ReferenceError: contents is not defined
```
